### PR TITLE
Make all references local for reliability and performance improvements.

### DIFF
--- a/compactmtgobjects/city_compact_object
+++ b/compactmtgobjects/city_compact_object
@@ -6,7 +6,7 @@
 	"properties": {
 		"uuid" : {
 			"description": "UUID of object (standardized by OSF)",
-			"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+			"$ref": "../sections/uuid_schema"
 		},
 		"type": { "type": "string", "pattern": "^city$" },
 		"hash": { "type": "string"},
@@ -19,10 +19,10 @@
 		"status": { "type": "string" },
 		"title": { "type": "string" },
 		"summary": { "type": "string" },            
-		"location": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/location/city_location_schema" },        
-		"translations": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/translations_schema" },
-		"map": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/map_schema" },
-		"images": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/image_schema" },
+		"location": { "$ref": "../location/city_location_schema" },
+		"translations": { "$ref": "../sections/translations_schema" },
+		"map": { "$ref": "../sections/map_schema" },
+		"images": { "$ref": "../sections/image_schema" },
 		"children_count": { "type": "integer" }
 	}
 }

--- a/compactmtgobjects/city_compactmtg_array
+++ b/compactmtgobjects/city_compactmtg_array
@@ -1,6 +1,6 @@
 {
 	"description": "Array of City Compact MTG Objects",
 	"type": "array",				
-	"items": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/city_compact_object" },
+	"items": { "$ref": "../compactmtgobjects/city_compact_object" },
 	"additionalItems": false
 }

--- a/compactmtgobjects/common_compact_object
+++ b/compactmtgobjects/common_compact_object
@@ -6,11 +6,11 @@
 	"properties": {
 		"uuid" : {
 			"description": "UUID of object (standardized by OSF)",
-			"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+			"$ref": "../sections/uuid_schema"
 		},
 		"type": { "type": "string" },
-		"content_provider": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/content_provider_schema" },
-		"publisher": {"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/publisher_compact_object"}, 
+		"content_provider": { "$ref": "../sections/content_provider_schema" },
+		"publisher": {"$ref": "../compactmtgobjects/publisher_compact_object"},
 		"language": { "type": "string" },   
 		"languages": { "type": "array" }, 		
 		"status": { "type": "string" },
@@ -22,18 +22,18 @@
 		"category": { "type": "string" },
 		"duration": { "type": "integer" },
 		"distance": { "type": "integer" },
-		"purchase": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/purchase_schema" },
-		"location": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/location/full_location_schema" },
-		"map": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/map_schema" },
+		"purchase": { "$ref": "../sections/purchase_schema" },
+		"location": { "$ref": "../location/full_location_schema" },
+		"map": { "$ref": "../sections/map_schema" },
 		"route": { "type": "string" },            
-		"trigger_zones": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/trigger_zones_schema" },
+		"trigger_zones": { "$ref": "../sections/trigger_zones_schema" },
 		"placement": { "type": "string" },
 		"hidden": { "type": "boolean" },
-		"images": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/image_schema" },
-		"city": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/city_compact_object" }, 
-		"country": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/country_compact_object" }, 
+		"images": { "$ref": "../sections/image_schema" },
+		"city": { "$ref": "../compactmtgobjects/city_compact_object" },
+		"country": { "$ref": "../compactmtgobjects/country_compact_object" },
 		"children_count": { "type": "integer" },
 		"audio_duration": { "type": "integer" },
-		"reviews": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/reviews_schema" }
+		"reviews": { "$ref": "../sections/reviews_schema" }
 	}
 }

--- a/compactmtgobjects/commoncompactmtg_array
+++ b/compactmtgobjects/commoncompactmtg_array
@@ -1,6 +1,6 @@
 {
 	"description": "Array of Compact MTG Objects",
 	"type": "array",				
-	"items": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/common_compact_object" },
+	"items": { "$ref": "../compactmtgobjects/common_compact_object" },
 	"additionalItems": false
 }

--- a/compactmtgobjects/country_compact_object
+++ b/compactmtgobjects/country_compact_object
@@ -6,7 +6,7 @@
 	"properties": {
 		"uuid" : {
 			"description": "UUID of object (standardized by OSF)",
-			"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+			"$ref": "../sections/uuid_schema"
 		},
 		"type": { "type": "string", "pattern": "^country$" },
 		"hash": { "type": "string"},
@@ -18,10 +18,10 @@
 		"status": { "type": "string" },
 		"title": { "type": "string" },
 		"summary": { "type": "string" },            
-		"location": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/location/simple_location_schema" },        
-		"translations": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/translations_schema" },
-		"images": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/image_schema" },
-		"map": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/map_schema" },
+		"location": { "$ref": "../location/simple_location_schema" },
+		"translations": { "$ref": "../sections/translations_schema" },
+		"images": { "$ref": "../sections/image_schema" },
+		"map": { "$ref": "../sections/map_schema" },
 		"children_count": { "type": "integer" },
 		"country_code": { "type": "string" }
 	}

--- a/compactmtgobjects/country_compactmtg_array
+++ b/compactmtgobjects/country_compactmtg_array
@@ -1,6 +1,6 @@
 {
 	"description": "Array of Country Compact MTG Objects",
 	"type": "array",				
-	"items": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/country_compact_object" },
+	"items": { "$ref": "../compactmtgobjects/country_compact_object" },
 	"additionalItems": false
 }

--- a/compactmtgobjects/publisher_compact_object
+++ b/compactmtgobjects/publisher_compact_object
@@ -6,10 +6,10 @@
 	"properties": {
 		"uuid" : {
 			"description": "UUID of object (standardized by OSF)",
-			"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+			"$ref": "../sections/uuid_schema"
 		},
 		"type": { "type": "string", "pattern": "^publisher$" },
-		"content_provider": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/content_provider_schema" },
+		"content_provider": { "$ref": "../sections/content_provider_schema" },
 		"language": { "type": "string" },   
 		"hash": { "type": "string"},
 		"languages": { "type": "array",
@@ -18,7 +18,7 @@
 		}, 		
 		"status": { "type": "string" },
 		"title": { "type": "string" },
-		"images": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/image_schema" },
+		"images": { "$ref": "../sections/image_schema" },
 		"summary": { "type": "string" }            
 	}
 }

--- a/mtgobjects/attraction_full_object
+++ b/mtgobjects/attraction_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string", "pattern": "^tourist_attraction$" },
 			"status": { "type": "string"},

--- a/mtgobjects/city_full_object
+++ b/mtgobjects/city_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string", "pattern": "^city$" },
 			"status": { "type": "string"},

--- a/mtgobjects/collection_full_object
+++ b/mtgobjects/collection_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string", "pattern": "^collection$" },
 			"status": { "type": "string"},
@@ -14,9 +14,9 @@
 			"size": { "type": "number"},
 			"languages": { "type": "array"},
 			"parent_uuid": { "type": "string"},			
-			"content_provider": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/content_provider_schema" },
-			"content": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/content_schema" },
-			"publisher": {"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/publisher_compact_object"},
+			"content_provider": { "$ref": "../sections/content_provider_schema" },
+			"content": { "$ref": "../sections/content_schema" },
+			"publisher": {"$ref": "../compactmtgobjects/publisher_compact_object"},
 		    "reviews": { "ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/reviews_schema" }	
 		}
 }

--- a/mtgobjects/common_full_object
+++ b/mtgobjects/common_full_object
@@ -6,29 +6,29 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string"},
 			"status": { "type": "string"},
 			"hash": { "type": "string"},
 			"languages": { "type": "array"},					
-			"content_provider": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/content_provider_schema" },
-			"content": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/content_schema" },
-			"publisher": {"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/publisher_compact_object"}, 
+			"content_provider": { "$ref": "../sections/content_provider_schema" },
+			"content": { "$ref": "../sections/content_schema" },
+			"publisher": {"$ref": "../compactmtgobjects/publisher_compact_object"},
 			"parent_uuid": { "type": "string"},
 			"category": { "type": "string"},
 			"duration": { "type": "number"},
 			"distance": { "type": "number"},
 			"placement": { "type": "string"},
 			"hidden": { "type": "boolean"},					
-			"location": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/location/full_location_schema" },
-			"trigger_zones": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/trigger_zones_schema" },
-			"map": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/map_schema" },
-			"purchase": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/purchase_schema" },
-			"schedule": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/schedule_schema" },
-			"contacts": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/contacts_schema" }, 
-			"city": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/city_compact_object" }, 
-			"country": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/compactmtgobjects/country_compact_object" },
-			"reviews": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/reviews_schema" }
+			"location": { "$ref": "../location/full_location_schema" },
+			"trigger_zones": { "$ref": "../sections/trigger_zones_schema" },
+			"map": { "$ref": "../sections/map_schema" },
+			"purchase": { "$ref": "../sections/purchase_schema" },
+			"schedule": { "$ref": "../sections/schedule_schema" },
+			"contacts": { "$ref": "../sections/contacts_schema" },
+			"city": { "$ref": "../compactmtgobjects/city_compact_object" },
+			"country": { "$ref": "../compactmtgobjects/country_compact_object" },
+			"reviews": { "$ref": "../sections/reviews_schema" }
 		}
 }

--- a/mtgobjects/commonfullmtg_array
+++ b/mtgobjects/commonfullmtg_array
@@ -1,6 +1,6 @@
 {
 	"description": "Array of Full MTG Objects",
 	"type": "array",				
-	"items": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/mtgobjects/common_full_object" },
+	"items": { "$ref": "../mtgobjects/common_full_object" },
 	"additionalItems": false
 }

--- a/mtgobjects/country_full_object
+++ b/mtgobjects/country_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string", "pattern": "^country$" },
 			"status": { "type": "string"},

--- a/mtgobjects/countryfull_array
+++ b/mtgobjects/countryfull_array
@@ -1,6 +1,6 @@
 {
 	"description": "Array of Full MTG Objects",
 	"type": "array",				
-	"items": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/mtgobjects/country_full_object" },
+	"items": { "$ref": "../mtgobjects/country_full_object" },
 	"additionalItems": false
 }

--- a/mtgobjects/exhibit_full_object
+++ b/mtgobjects/exhibit_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string", "pattern": "^exhibit$" },
 			"status": { "type": "string"},

--- a/mtgobjects/museum_full_object
+++ b/mtgobjects/museum_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string", "pattern": "^museum$" },
 			"status": { "type": "string"},

--- a/mtgobjects/nav_story_full_object
+++ b/mtgobjects/nav_story_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string", "pattern": "^story_navigation$" },
 			"status": { "type": "string"},

--- a/mtgobjects/publisher_full_object
+++ b/mtgobjects/publisher_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string"},
 			"status": { "type": "string"},

--- a/mtgobjects/tour_full_object
+++ b/mtgobjects/tour_full_object
@@ -6,7 +6,7 @@
 		"properties": {
 			"uuid" : {
 				"description": "UUID of object (standardized by OSF)",
-				"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+				"$ref": "../sections/uuid_schema"
 			},
 			"type": { "type": "string", "pattern": "^tour$" },
 			"status": { "type": "string"},

--- a/sections/content_provider_schema
+++ b/sections/content_provider_schema
@@ -13,7 +13,7 @@
 		},
 		"uuid" : {
 			"description": "UUID of object (standardized by OSF)",
-			"$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/uuid_schema"
+			"$ref": "../sections/uuid_schema"
 		}
 	}
 }

--- a/sections/download_schema
+++ b/sections/download_schema
@@ -4,11 +4,11 @@
 		"additionalProperties": false,
 		"required": ["ios-jpg:low-m4a-mp4", "ios-jpg:high-m4a-mp4", "android-jpg:low-m4a-mp4", "android-jpg:high-m4a-mp4"],
 		"properties": {
-			"ios-jpg:low-m4a-mp4": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/download_props_schema" },
-			"ios-jpg:high-m4a-mp4": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/download_props_schema" },
-			"android-jpg:low-m4a-mp4": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/download_props_schema" },
-			"android-jpg:high-m4a-mp4": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/download_props_schema" },
-			"video": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/download_props_schema" },
-			"map-mbtiles": { "$ref": "https://raw.githubusercontent.com/iziteq/izi-api-schemes/master/sections/download_props_schema" }
+			"ios-jpg:low-m4a-mp4": { "$ref": "../sections/download_props_schema" },
+			"ios-jpg:high-m4a-mp4": { "$ref": "../sections/download_props_schema" },
+			"android-jpg:low-m4a-mp4": { "$ref": "../sections/download_props_schema" },
+			"android-jpg:high-m4a-mp4": { "$ref": "../sections/download_props_schema" },
+			"video": { "$ref": "../sections/download_props_schema" },
+			"map-mbtiles": { "$ref": "../sections/download_props_schema" }
 		}
 }


### PR DESCRIPTION
We validate messages a lot and every time multiple schemas are retrieved from Github. This causes a single validation to take between 500ms and 1000ms. All required schema files seem to come from the same repository anyway, so this PR changes the references from locations on Github to the local files. I tested it using https://github.com/justinrainbow/json-schema and all references are loaded from their local files, speeding up our tests significantly.
